### PR TITLE
Fixed DecoderConvBock typo in encdec.py and conditioners.py

### DIFF
--- a/jukebox/prior/conditioners.py
+++ b/jukebox/prior/conditioners.py
@@ -2,7 +2,7 @@ import torch as t
 import torch.nn as nn
 
 from jukebox.transformer.ops import LayerNorm
-from jukebox.vqvae.encdec import DecoderConvBock
+from jukebox.vqvae.encdec import DecoderConvBlock
 from jukebox.utils.torch_utils import assert_shape
 
 class Conditioner(nn.Module):
@@ -16,7 +16,7 @@ class Conditioner(nn.Module):
         nn.init.normal_(self.x_emb.weight, std=0.02 * init_scale)
 
         # Conditioner
-        self.cond = DecoderConvBock(self.width, self.width, down_t, stride_t, **block_kwargs, zero_out=zero_out, res_scale=res_scale)
+        self.cond = DecoderConvBlock(self.width, self.width, down_t, stride_t, **block_kwargs, zero_out=zero_out, res_scale=res_scale)
         self.ln = LayerNorm(self.width)
 
     def preprocess(self, x):

--- a/jukebox/vqvae/encdec.py
+++ b/jukebox/vqvae/encdec.py
@@ -25,7 +25,7 @@ class EncoderConvBlock(nn.Module):
     def forward(self, x):
         return self.model(x)
 
-class DecoderConvBock(nn.Module):
+class DecoderConvBlock(nn.Module):
     def __init__(self, input_emb_width, output_emb_width, down_t,
                  stride_t, width, depth, m_conv, dilation_growth_rate=1, dilation_cycle=None, zero_out=False, res_scale=False, reverse_decoder_dilation=False, checkpoint_res=False):
         super().__init__()
@@ -96,7 +96,7 @@ class Decoder(nn.Module):
 
         self.strides_t = strides_t
 
-        level_block = lambda level, down_t, stride_t: DecoderConvBock(output_emb_width,
+        level_block = lambda level, down_t, stride_t: DecoderConvBlock(output_emb_width,
                                                           output_emb_width,
                                                           down_t, stride_t,
                                                           **block_kwargs)


### PR DESCRIPTION
DecoderConvBock is mispelled in several places in the code:

For example:
https://github.com/openai/jukebox/blob/7b9d42cda4acc2ec3c11ebde6ebc09f86f7b9d34/jukebox/vqvae/encdec.py#L28

and 

https://github.com/openai/jukebox/blob/7b9d42cda4acc2ec3c11ebde6ebc09f86f7b9d34/jukebox/prior/conditioners.py#L19

But EncoderConvBlock is correctly spelled