### PR TITLE
Fix Colab co-composing variables

### DIFF
--- a/jukebox/Interacting_with_Jukebox.ipynb
+++ b/jukebox/Interacting_with_Jukebox.ipynb
@@ -660,7 +660,7 @@
       "source": [
         "# Set to True to load the previous checkpoint:\n",
         "if False:\n",
-        "  zs=t.load('zs-checkpoint.t') "
+        "  zs=t.load('zs-checkpoint2.t') "
       ],
       "execution_count": 0,
       "outputs": []
@@ -684,7 +684,7 @@
       },
       "source": [
         "continue_generation_in_seconds=4\n",
-        "tokens_to_sample = seconds_to_tokens(initial_generation_in_seconds, hps.sr, top_prior, chunk_size)"
+        "tokens_to_sample = seconds_to_tokens(continue_generation_in_seconds, hps.sr, top_prior, chunk_size)"
       ],
       "execution_count": 0,
       "outputs": []


### PR DESCRIPTION
There are some little mistakes in the co-composing section at the Colab notebook. While loading a checkpoint it searches for a file that does not correspond with the previous one created. Another problem is that the seconds variable that is being used to continue the generation is set to the initial one.