### PR TITLE
Inference support for windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ Code for "Jukebox: A Generative Model for Music"
 # Required: Sampling
 conda create --name jukebox python=3.7.5
 conda activate jukebox
-conda install mpi4py=3.0.3
 conda install pytorch=1.4 torchvision=0.5 cudatoolkit=10.0 -c pytorch
+pip install mpi4py==3.0.3
 git clone https://github.com/openai/jukebox.git
 cd jukebox
 pip install -r requirements.txt

--- a/jukebox/data/artist_genre_processor.py
+++ b/jukebox/data/artist_genre_processor.py
@@ -75,7 +75,7 @@ class ArtistGenreProcessor():
     def load_artists(self):
         print(f'Loading artist IDs from {self.artist_id_file}')
         self.artist_ids = {}
-        with open(self.artist_id_file, 'r') as f:
+        with open(self.artist_id_file, 'r', encoding="utf-8") as f:
             for line in f:
                 artist, artist_id = line.strip().split(';')
                 self.artist_ids[artist.lower()] = int(artist_id)
@@ -84,7 +84,7 @@ class ArtistGenreProcessor():
     def load_genres(self):
         print(f'Loading artist IDs from {self.genre_id_file}')
         self.genre_ids = {}
-        with open(self.genre_id_file, 'r') as f:
+        with open(self.genre_id_file, 'r', encoding="utf-8") as f:
             for line in f:
                 genre, genre_id = line.strip().split(';')
                 self.genre_ids[genre.lower()] = int(genre_id)

--- a/jukebox/data/data_processor.py
+++ b/jukebox/data/data_processor.py
@@ -1,5 +1,5 @@
 import torch as t
-import torch.distributed as dist
+import jukebox.utils.dist_adapter as dist
 from torch.utils.data.distributed import DistributedSampler
 from torch.utils.data import DataLoader, Dataset, BatchSampler, RandomSampler
 from jukebox.utils.dist_utils import print_all

--- a/jukebox/data/files_dataset.py
+++ b/jukebox/data/files_dataset.py
@@ -1,7 +1,7 @@
 import librosa
 import math
 import numpy as np
-import torch.distributed as dist
+import jukebox.utils.dist_adapter as dist
 from torch.utils.data import Dataset
 from jukebox.utils.dist_utils import print_all
 from jukebox.utils.io import get_duration_sec, load_audio

--- a/jukebox/make_models.py
+++ b/jukebox/make_models.py
@@ -6,7 +6,7 @@ Test on dummy outputs to see if everything matches
 import os
 import numpy as np
 import torch as t
-import torch.distributed as dist
+import jukebox.utils.dist_adapter as dist
 from jukebox.hparams import Hyperparams, setup_hparams
 from jukebox.utils.gcs_utils import download
 from jukebox.utils.torch_utils import freeze_model

--- a/jukebox/prior/prior.py
+++ b/jukebox/prior/prior.py
@@ -1,7 +1,7 @@
 import numpy as np
 import torch as t
 import torch.nn as nn
-import torch.distributed as dist
+import jukebox.utils.dist_adapter as dist
 
 from jukebox.transformer.ops import LayerNorm
 from jukebox.prior.autoregressive import ConditionalAutoregressive2D

--- a/jukebox/train.py
+++ b/jukebox/train.py
@@ -8,7 +8,7 @@ import fire
 import warnings
 import numpy as np
 import torch as t
-import torch.distributed as dist
+import jukebox.utils.dist_adapter as dist
 from torch.nn.parallel import DistributedDataParallel
 
 from jukebox.hparams import setup_hparams

--- a/jukebox/transformer/transformer.py
+++ b/jukebox/transformer/transformer.py
@@ -2,7 +2,7 @@ import functools
 import numpy as np
 import torch as t
 import torch.nn as nn
-import torch.distributed as dist
+import jukebox.utils.dist_adapter as dist
 
 from jukebox.transformer.ops import Conv1D, ACT_FNS, LayerNorm
 from jukebox.transformer.factored_attention import FactoredAttention

--- a/jukebox/utils/audio_utils.py
+++ b/jukebox/utils/audio_utils.py
@@ -1,6 +1,6 @@
 import numpy as np
 import torch as t
-import torch.distributed as dist
+import jukebox.utils.dist_adapter as dist
 import soundfile
 import librosa
 from jukebox.utils.dist_utils import print_once

--- a/jukebox/utils/dist_adapter.py
+++ b/jukebox/utils/dist_adapter.py
@@ -1,0 +1,92 @@
+import torch.distributed as dist
+from enum import Enum
+
+class ReduceOp(Enum):
+    SUM = 0,
+    PRODUCT = 1,
+    MIN = 2,
+    MAX = 3,
+    BAND = 4, # Bitwise AND
+    BOR = 5, # Bitwise OR
+    BXOR = 6, # Bitwise XOR
+
+    def ToDistOp(self):
+        return {
+            self.SUM: dist.ReduceOp.SUM,
+            self.PRODUCT: dist.ReduceOp.PRODUCT,
+            self.MIN: dist.ReduceOp.MIN,
+            self.MAX: dist.ReduceOp.MAX,
+            self.BAND: dist.ReduceOp.BAND,
+            self.BOR: dist.ReduceOp.BOR,
+            self.BXOR: dist.ReduceOp.BXOR
+        }[self]
+
+def is_available():
+    return dist.is_available()
+
+def get_rank():
+    if is_available():
+        return _get_rank()
+    else:
+        return 0
+
+def get_world_size():
+    if is_available():
+        return _get_world_size()
+    else:
+        return 1
+
+def barrier():
+    if is_available():
+        return _barrier()
+    #else: do nothing
+
+def all_gather(tensor_list, tensor):
+    if is_available():
+        return _all_gather(tensor_list, tensor)
+    else:
+        tensor_list[0] = tensor
+
+def all_reduce(tensor, op=ReduceOp.SUM):
+    if is_available():
+        return _all_reduce(tensor, op)
+    #else: do nothing
+
+def reduce(tensor, dst, op=ReduceOp.SUM):
+    if is_available():
+        return _reduce(tensor, dst, op)
+    #else: do nothing
+
+def broadcast(tensor, src):
+    if is_available():
+        return _broadcast(tensor, src)
+    #else: do nothing
+
+def init_process_group(backend, init_method):
+    if is_available():
+        return _init_process_group(backend, init_method)
+    #else: do nothing
+
+def _get_rank():
+    return dist.get_rank()
+
+def _barrier():
+    return dist.barrier()
+
+def _get_world_size():
+    return dist.get_world_size()
+
+def _all_gather(tensor_list, tensor):
+    return dist.all_gather(tensor_list, tensor)
+
+def _all_reduce(tensor, op):
+    return dist.all_reduce(tensor, op.ToDistOp())
+
+def _reduce(tensor, dst, op=ReduceOp.SUM):
+    return dist.reduce(tensor, dst, op.ToDistOp())
+
+def _broadcast(tensor, src):
+    return dist.broadcast(tensor, src)
+
+def _init_process_group(backend, init_method):
+    return dist.init_process_group(backend, init_method)

--- a/jukebox/utils/dist_adapter.py
+++ b/jukebox/utils/dist_adapter.py
@@ -5,20 +5,14 @@ class ReduceOp(Enum):
     SUM = 0,
     PRODUCT = 1,
     MIN = 2,
-    MAX = 3,
-    BAND = 4, # Bitwise AND
-    BOR = 5, # Bitwise OR
-    BXOR = 6, # Bitwise XOR
+    MAX = 3
 
     def ToDistOp(self):
         return {
             self.SUM: dist.ReduceOp.SUM,
             self.PRODUCT: dist.ReduceOp.PRODUCT,
             self.MIN: dist.ReduceOp.MIN,
-            self.MAX: dist.ReduceOp.MAX,
-            self.BAND: dist.ReduceOp.BAND,
-            self.BOR: dist.ReduceOp.BOR,
-            self.BXOR: dist.ReduceOp.BXOR
+            self.MAX: dist.ReduceOp.MAX
         }[self]
 
 def is_available():
@@ -82,7 +76,7 @@ def _all_gather(tensor_list, tensor):
 def _all_reduce(tensor, op):
     return dist.all_reduce(tensor, op.ToDistOp())
 
-def _reduce(tensor, dst, op=ReduceOp.SUM):
+def _reduce(tensor, dst, op):
     return dist.reduce(tensor, dst, op.ToDistOp())
 
 def _broadcast(tensor, src):

--- a/jukebox/utils/dist_utils.py
+++ b/jukebox/utils/dist_utils.py
@@ -1,7 +1,7 @@
 import os
 from time import sleep
 import torch
-import torch.distributed as dist
+import jukebox.utils.dist_adapter as dist
 
 def print_once(msg):
     if (not dist.is_available()) or dist.get_rank()==0:
@@ -42,6 +42,21 @@ def allgather_lists(xs):
 def setup_dist_from_mpi(
     master_addr="127.0.0.1", backend="nccl", port=29500, n_attempts=5, verbose=False
 ):
+    if dist.is_available():
+        return _setup_dist_from_mpi(master_addr, backend, port, n_attempts, verbose)
+    else:
+        use_cuda = torch.cuda.is_available()
+        print(f'Using cuda {use_cuda}')
+
+        mpi_rank = 0
+        local_rank = 0
+
+        device = torch.device("cuda", local_rank) if use_cuda else torch.device("cpu")
+        torch.cuda.set_device(local_rank)
+
+        return mpi_rank, local_rank, device
+
+def _setup_dist_from_mpi(master_addr, backend, port, n_attempts, verbose):
     from mpi4py import MPI  # This must be imported in order to get e   rrors from all ranks to show up
 
     mpi_rank = MPI.COMM_WORLD.Get_rank()

--- a/jukebox/utils/fp16.py
+++ b/jukebox/utils/fp16.py
@@ -3,7 +3,7 @@ import importlib
 import math
 import numpy as np
 import torch
-import torch.distributed as dist
+import jukebox.utils.dist_adapter as dist
 from torch.optim import Optimizer
 from torch._utils import _flatten_dense_tensors
 

--- a/jukebox/utils/io.py
+++ b/jukebox/utils/io.py
@@ -1,7 +1,7 @@
 import numpy as np
 import av
 import torch as t
-import torch.distributed as dist
+import jukebox.utils.dist_adapter as dist
 
 def get_duration_sec(file, cache=False):
     try:

--- a/jukebox/utils/logger.py
+++ b/jukebox/utils/logger.py
@@ -1,5 +1,5 @@
 import torch as t
-import torch.distributed as dist
+import jukebox.utils.dist_adapter as dist
 from tqdm import tqdm
 from datetime import date
 import os

--- a/jukebox/vqvae/bottleneck.py
+++ b/jukebox/vqvae/bottleneck.py
@@ -2,7 +2,7 @@ import numpy as np
 import torch as t
 import torch.nn as nn
 import torch.nn.functional as F
-import torch.distributed as dist
+import jukebox.utils.dist_adapter as dist
 
 class BottleneckBlock(nn.Module):
     def __init__(self, k_bins, emb_width, mu):

--- a/jukebox/vqvae/resnet.py
+++ b/jukebox/vqvae/resnet.py
@@ -1,6 +1,6 @@
 import math
 import torch.nn as nn
-import torch.distributed as dist
+import jukebox.utils.dist_adapter as dist
 from jukebox.utils.checkpoint import checkpoint
 
 class ResConvBlock(nn.Module):


### PR DESCRIPTION
Tried to abstract `torch.distributed` the most subtle way possible, so all references from the jukebox are replaced with the adapter:
- If `torch.dist` is available, the adapter proxies the call further into the framework.
- If `torch.dist` is not available, the adapter emulates single node behavior.

I haven't modified any references from the APEX as it should support windows by default.

Training is not supported for windows as it is relying a lot on the distributed processing (`DistributedDataParallel`, `DistributedSampler`, fork multiprocessing, etc)

The models has to be downloaded manually at the moment for windows, I'll fix it in the next PR.

Also, few modifications has been made:
- `mpi4py` is installed from pip instead of conda (`mpi4py` is not available from conda for windows for some reason)
- explcit `encoding="utf-8"` is provided when opening the genre/artist labels in `artist_genre_processor.py`

Installation has been tested on clean environments for windows and ubuntu 

Inference has been tested for:
- 1b_lyrics, windows, single node without torch.distributed available
- 1b_lyrics, ubuntu, single node with torch.distributed available

Training has been tested for:
- small_vqvae, ubuntu, single node with torch.distributed available

Issue: https://github.com/openai/jukebox/issues/36