### PR TITLE
README.md typo fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ mpiexec -n {ngpus} python jukebox/train.py --hps=small_vqvae,small_upsampler,all
 --restore_vqvae=logs/small_vqvae/checkpoint_latest.pth.tar --prior --levels=2 --level=0 --weight_decay=0.01 --save_iters=1000
 ```
 We pass `sample_length = n_ctx * downsample_of_level` so that after downsampling the tokens match the n_ctx of the prior hps. 
-Here, `n_ctx = 8192` and `downsamples = (32, 256)`, giving `sample_lengths = (8192 * 32, 8192 * 256) = (65536, 2097152)` respectively for the bottom and top level. 
+Here, `n_ctx = 8192` and `downsamples = (32, 256)`, giving `sample_lengths = (8192 * 32, 8192 * 256) = (262144, 2097152)` respectively for the bottom and top level. 
 
 ### Learning rate annealing
 To get the best sample quality anneal the learning rate to 0 near the end of training. To do so, continue training from the latest 


### PR DESCRIPTION
Training commands above contain correct sample_lengths, but there is a small typo in a description of these commands