### PR TITLE
Use --depth flag to git clone in Dockerfiles, to save space

### DIFF
--- a/apex/examples/docker/Dockerfile
+++ b/apex/examples/docker/Dockerfile
@@ -10,7 +10,7 @@ RUN pip uninstall -y apex || :
 RUN pip uninstall -y apex || :
 # SHA is something the user can touch to force recreation of this Docker layer,
 # and therefore force cloning of the latest version of Apex
-RUN SHA=ToUcHMe git clone https://github.com/NVIDIA/apex.git
+RUN SHA=ToUcHMe git clone --depth 1 https://github.com/NVIDIA/apex.git
 WORKDIR /tmp/unique_for_apex/apex
 RUN pip install -v --no-cache-dir --global-option="--cpp_ext" --global-option="--cuda_ext" .
 WORKDIR /workspace


### PR DESCRIPTION
optimize the git clone using --depth flag in term of size of clone
and also in term's of time taken to fetch the files and commit history
of whole repository .

More detail can be found at blog
https://www.atlassian.com/git/tutorials/big-repositories

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>