### PR TITLE
fix(sec): upgrade numba to 0.49.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ fire==0.1.3
 tqdm==4.45.0
 soundfile==0.10.3.post1
 unidecode==1.1.1
-numba==0.48.0
+numba==0.49.0
 librosa==0.7.2
 mpi4py>=3.0.0


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in numba 0.48.0
- [MPS-2022-15007](https://www.oscs1024.com/hd/MPS-2022-15007)


### What did I do？
Upgrade numba from 0.48.0 to 0.49.0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS